### PR TITLE
add postman collection with example calls for each endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 API documentation can be found [here](https://ece493group8.github.io/word2med-backend/)
 
+### Postman
+
+A [postman](https://www.postman.com/) collection with usage examples for each endpoint is exported to [`Word2Med.postman_collection.json`](./Word2Med.postman_collection.json).
+
+To use, simply import this file within [postman](https://www.postman.com/).
+
 ## Development Configuration
 
 Follow these steps to run the word2med backend locally

--- a/Word2Med.postman_collection.json
+++ b/Word2Med.postman_collection.json
@@ -1,0 +1,265 @@
+{
+	"info": {
+		"_postman_id": "07b7fa2d-c8d0-4546-8767-a1477b93d5ba",
+		"name": "Word2Med",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "25957943"
+	},
+	"item": [
+		{
+			"name": "Vector",
+			"item": [
+				{
+					"name": "Vector",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/vector?word=pain",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"vector"
+							],
+							"query": [
+								{
+									"key": "word",
+									"value": "pain"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Neighbourhood",
+			"item": [
+				{
+					"name": "Neighbourhood single word",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/neighbours?words=pain&n=5",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"neighbours"
+							],
+							"query": [
+								{
+									"key": "words",
+									"value": "pain"
+								},
+								{
+									"key": "n",
+									"value": "5"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Neighbourhood multiple words",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/neighbours?words=pain&words=boy&n=5",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"neighbours"
+							],
+							"query": [
+								{
+									"key": "words",
+									"value": "pain"
+								},
+								{
+									"key": "words",
+									"value": "boy"
+								},
+								{
+									"key": "n",
+									"value": "5"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Analogy",
+			"item": [
+				{
+					"name": "Analogy",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseURL}}/analogy?a=man&b=woman&c=husband&n=5",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"analogy"
+							],
+							"query": [
+								{
+									"key": "a",
+									"value": "man"
+								},
+								{
+									"key": "b",
+									"value": "woman"
+								},
+								{
+									"key": "c",
+									"value": "husband"
+								},
+								{
+									"key": "n",
+									"value": "5"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Embeddings",
+			"item": [
+				{
+					"name": "Embeddings single word",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseURL}}/embeddings?words=pain&n=10",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"embeddings"
+							],
+							"query": [
+								{
+									"key": "words",
+									"value": "pain"
+								},
+								{
+									"key": "n",
+									"value": "10"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Embeddings multiple words",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseURL}}/embeddings?words=back&words=pain&n=10",
+							"host": [
+								"{{baseURL}}"
+							],
+							"path": [
+								"embeddings"
+							],
+							"query": [
+								{
+									"key": "words",
+									"value": "back"
+								},
+								{
+									"key": "words",
+									"value": "pain"
+								},
+								{
+									"key": "n",
+									"value": "10"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "baseURL",
+			"value": "http://127.0.0.1:5000",
+			"type": "string"
+		},
+		{
+			"key": "devURL",
+			"value": "http://127.0.0.1:5000",
+			"type": "string"
+		},
+		{
+			"key": "prodURL",
+			"value": "http://129.128.215.93:5000",
+			"type": "string"
+		}
+	]
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -112,22 +112,22 @@ paths:
         analogy "a is to b as c is to d"
       parameters:
       - in: query
-        name: b
+        name: n
         required: false
         schema:
-          type: string
+          type: integer
       - in: query
         name: c
         required: false
         schema:
           type: string
       - in: query
-        name: n
+        name: a
         required: false
         schema:
-          type: integer
+          type: string
       - in: query
-        name: a
+        name: b
         required: false
         schema:
           type: string


### PR DESCRIPTION
Closes #13 

@ashutoshlamba @woodepic If you import this collection into [postman](https://www.postman.com/) there is example calls for each endpoint. Postman has a code generation feature too which could be helpful

api docs [here](https://ece493group8.github.io/word2med-backend/)